### PR TITLE
Also append or remove the unit string for common CSS preprocessor files

### DIFF
--- a/src/com/kstenschke/shifter/models/ShiftableWord.java
+++ b/src/com/kstenschke/shifter/models/ShiftableWord.java
@@ -112,7 +112,11 @@ public class ShiftableWord {
 	public String postProcess(String word) {
 		int wordType = this.getWordType();
 
-		if(this.filename.toLowerCase().endsWith(".css")) {
+		if(this.filename.toLowerCase().endsWith(".css")
+		|| this.filename.toLowerCase().endsWith(".scss")
+		|| this.filename.toLowerCase().endsWith(".sass")
+		|| this.filename.toLowerCase().endsWith(".less")
+		|| this.filename.toLowerCase().endsWith(".styl")) {
 			switch(wordType) {
 				// "0" was shifted to a different numeric value, inside a CSS file, so we can add a measure unit
 				case ShifterTypesManager.TYPE_NUMERIC_VALUE:


### PR DESCRIPTION
Hey i fixed this little improvement myself, hope you are ok with that. I was just wondering why this new unit functionality is not working for me, but it's just because i'm working with SASS files instead of plain CSS.
